### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ And, since they're interfaces, you can implement multiple of them.
 
     :::java
     public interface Thrower {
-        public void throwIfCondition(boolean condition, String msg) {
+        default void throwIfCondition(boolean condition, String msg) {
             // ...
         }
 
-        public void throwAorB(Throwable a, Throwable b, boolean throwA) {
+        default void throwAorB(Throwable a, Throwable b, boolean throwA) {
             // ...
         }
     }


### PR DESCRIPTION
default methods should have the `default` keyword and `public` is redundant since an interface contains only public methods. In an interface public is the default if there is no access modifier.
