### PR TITLE
Change code block markdown to allow syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,41 +68,41 @@ object.
 Imagine we had a more complicated *DataHolder*. The builder for it might look
 like:
 
-    ```java
-    public class ComplicatedDataHolder {
-        public final String data;
-        public final int num;
-        // lots more fields and a constructor
+```java
+public class ComplicatedDataHolder {
+    public final String data;
+    public final int num;
+    // lots more fields and a constructor
 
-        public static class Builder {
-            private String data;
-            private int num;
-            
-            public Builder data(String data) {
-                this.data = data;
-                return this;
-            }
-
-            public Builder num(int num) {
-                this.num = num;
-                return this;
-            }
-
-            public ComplicatedDataHolder build() {
-                return new ComplicatedDataHolder(data, num); // etc
-            }  
+    public static class Builder {
+        private String data;
+        private int num;
+        
+        public Builder data(String data) {
+            this.data = data;
+            return this;
         }
+
+        public Builder num(int num) {
+            this.num = num;
+            return this;
+        }
+
+        public ComplicatedDataHolder build() {
+            return new ComplicatedDataHolder(data, num); // etc
+        }  
     }
-    ```
+}
+```
 
 Then to use it:
 
-    ```java
-    final ComplicatedDataHolder cdh = new ComplicatedDataHolder.Builder()
-        .data("set this")
-        .num(523)
-        .build();
-    ```
+```java
+final ComplicatedDataHolder cdh = new ComplicatedDataHolder.Builder()
+    .data("set this")
+    .num(523)
+    .build();
+```
 
 There are [better examples of Builders elsewhere][builderex] but this should
 give you a taste for what it's like. This ends up with a lot of the boilerplate
@@ -138,37 +138,37 @@ If you're using [Java 8][java8], you can use the excellent new
 [Optional][optional] type. If a value may or may not be present, wrap it in
 an *Optional* class like this:
 
-    ```java
-    public class FooWidget {
-        private final String data;
-        private final Optional<Bar> bar;
+```java
+public class FooWidget {
+    private final String data;
+    private final Optional<Bar> bar;
 
-        public FooWidget(String data) {
-            this(data, Optional.empty());
-        }
-
-        public FooWidget(String data, Optional<Bar> bar) {
-            this.data = data;
-            this.bar = bar;
-        }
-
-        public Optional<Bar> getBar() {
-            return bar;
-        }
+    public FooWidget(String data) {
+        this(data, Optional.empty());
     }
-    ```
+
+    public FooWidget(String data, Optional<Bar> bar) {
+        this.data = data;
+        this.bar = bar;
+    }
+
+    public Optional<Bar> getBar() {
+        return bar;
+    }
+}
+```
 
 So now it's clear that *data* will never be null, but *bar* may or may not be
 present. *Optional* has methods like *isPresent*, which may make it feel like
 not a lot is different from just checking *null*. But it allows you to write
 statements like:
 
-    ```java
-    final Optional<FooWidget> fooWidget = maybeGetFooWidget();
-    final Baz baz = fooWidget.flatMap(FooWidget::getBar)
-                             .flatMap(BarWidget::getBaz)
-                             .orElse(defaultBaz);
-    ```
+```java
+final Optional<FooWidget> fooWidget = maybeGetFooWidget();
+final Baz baz = fooWidget.flatMap(FooWidget::getBar)
+                         .flatMap(BarWidget::getBaz)
+                         .orElse(defaultBaz);
+```
 
 Which is much better than chained if null checks. The only downside of using
 Optional is that the standard library doesn't have good Optional support, so
@@ -181,20 +181,20 @@ collections should be immutable.
 
 Variable references can be made immutable with *final*:
 
-    ```java
-    final FooWidget fooWidget;
-    if (condition()) {
-        fooWidget = getWidget();
-    } else {
-        try {
-            fooWidget = cachedFooWidget.get();
-        } catch (CachingException e) {
-            log.error("Couldn't get cached value", e);
-            throw e;
-        }
+```java
+final FooWidget fooWidget;
+if (condition()) {
+    fooWidget = getWidget();
+} else {
+    try {
+        fooWidget = cachedFooWidget.get();
+    } catch (CachingException e) {
+        log.error("Couldn't get cached value", e);
+        throw e;
     }
-    // fooWidget is guaranteed to be set here
-    ```
+}
+// fooWidget is guaranteed to be set here
+```
 
 Now you can be sure that fooWidget won't be accidentally reassigned. The *final*
 keyword works with if/else blocks and with try/catch blocks. Of course, if the
@@ -213,17 +213,17 @@ and by using immutable collections. Optionally, you can make the class itself
 
 Be careful if you find yourself adding a lot of methods to a Util class.
 
-    ```java
-    public class MiscUtil {
-        public static String frobnicateString(String base, int times) {
-            // ... etc
-        }
-
-        public static void throwIfCondition(boolean condition, String msg) {
-            // ... etc
-        }
+```java
+public class MiscUtil {
+    public static String frobnicateString(String base, int times) {
+        // ... etc
     }
-    ```
+
+    public static void throwIfCondition(boolean condition, String msg) {
+        // ... etc
+    }
+}
+```
 
 These classes, at first, seem attractive because the methods that go in them
 don't really belong in any one place. So you throw them all in here in the
@@ -234,17 +234,17 @@ if you must have common methods like this, consider [Java 8][java8]'s default
 methods on interfaces. Then you could lump common actions into interfaces. 
 And, since they're interfaces, you can implement multiple of them.
 
-    ```java
-    public interface Thrower {
-        default void throwIfCondition(boolean condition, String msg) {
-            // ...
-        }
-
-        default void throwAorB(Throwable a, Throwable b, boolean throwA) {
-            // ...
-        }
+```java
+public interface Thrower {
+    default void throwIfCondition(boolean condition, String msg) {
+        // ...
     }
-    ```
+
+    default void throwAorB(Throwable a, Throwable b, boolean throwA) {
+        // ...
+    }
+}
+```
 
 Then every class which needs it can simply implement this interface.
 
@@ -275,23 +275,23 @@ all, as it tricks your users into thinking that there is documentation.
 [Java 8][java8] has a nice [stream][javastream] and lambda syntax. You could
 write code like this:
 
-    ```java
-    final List<String> filtered = list.stream()
-        .filter(s -> s.startsWith("s"))
-        .map(s -> s.toUpperCase())
-        .collect(Collectors.toList());
-    ```
+```java
+final List<String> filtered = list.stream()
+    .filter(s -> s.startsWith("s"))
+    .map(s -> s.toUpperCase())
+    .collect(Collectors.toList());
+```
 
 Instead of this:
 
-    ```java
-    final List<String> filtered = new ArrayList<>();
-    for (String str : list) {
-        if (str.startsWith("s") {
-            filtered.add(str.toUpperCase());
-        }
+```java
+final List<String> filtered = new ArrayList<>();
+for (String str : list) {
+    if (str.startsWith("s") {
+        filtered.add(str.toUpperCase());
     }
-    ```
+}
+```
 
 This allows you to write more fluent code, which is more readable.
 
@@ -341,14 +341,14 @@ information.  This way, you get your company's selected version of each
 external dependency, and all of the correct Maven plugins. If you need to pull
 in external dependencies, it works just like this:
 
-    ```xml
-    <dependencies>
-        <dependency>
-            <groupId>org.third.party</groupId>
-            <artifactId>some-artifact</artifactId>
-        </dependency>
-    </dependencies>
-    ```
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.third.party</groupId>
+        <artifactId>some-artifact</artifactId>
+    </dependency>
+</dependencies>
+```
 
 If you want internal dependencies, that should be managed by each individual
 project's **<dependencyManagement>** section. Otherwise it would be difficult
@@ -460,13 +460,13 @@ cache and you're all set!
 
 I also like writing mutable collections the Guava way:
 
-    ```java
-    // Instead of
-    final Map<String, Widget> map = new HashMap<>();
-    
-    // You can use
-    final Map<String, Widget> map = Maps.newHashMap();
-    ```
+```java
+// Instead of
+final Map<String, Widget> map = new HashMap<>();
+
+// You can use
+final Map<String, Widget> map = Maps.newHashMap();
+```
 
 There are static classes for [Lists][lists], [Maps][maps], [Sets][sets] and
 more. They're cleaner and easier to read.
@@ -484,12 +484,12 @@ separators and a [class to handle interrupts][uninterrupt] by ignoring them.
 Google's [Gson][gson] library is a simple and fast JSON parsing library. It
 works like this:
 
-    ```java
-    final Gson gson = new Gson();
-    final String json = gson.toJson(fooWidget);
-    
-    final FooWidget newFooWidget = gson.fromJson(json, FooWidget.class);
-    ```
+```java
+final Gson gson = new Gson();
+final String json = gson.toJson(fooWidget);
+
+final FooWidget newFooWidget = gson.fromJson(json, FooWidget.class);
+```
 
 It's really easy and a pleasure to work with. The [Gson user guide][gsonguide]
 has many more examples.
@@ -502,12 +502,12 @@ that.
 
 It's simple to use and works great:
 
-    ```java
-    Pair<String, Integer> func(String input) {
-        // something...
-        return Pair.with(stringResult, intResult);
-    }
-    ```
+```java
+Pair<String, Integer> func(String input) {
+    // something...
+    return Pair.with(stringResult, intResult);
+}
+```
 
 ### Joda-Time
 
@@ -524,18 +524,18 @@ to reduce the boilerplate that Java suffers from so badly.
 
 Want setters and getters for your class variables? Simple:
 
-    ```java
-    public class Foo {
-        @Getter @Setter private int var;
-    }
-    ```
+```java
+public class Foo {
+    @Getter @Setter private int var;
+}
+```
 
 Now you can do this:
 
-    ```java
-    final Foo foo = new Foo();
-    foo.setVar(5);
-    ```
+```java
+final Foo foo = new Foo();
+foo.setVar(5);
+```
 
 And there's [so much more][lombokguide]. I haven't used Lombok in production
 yet, but I can't wait to.
@@ -581,16 +581,16 @@ much better solution.
 
 It lets you write SQL in Java in a type safe way:
 
-    ```java
-    // Typesafely execute the SQL statement directly with jOOQ
-    Result<Record3<String, String, String>> result = 
-    create.select(BOOK.TITLE, AUTHOR.FIRST_NAME, AUTHOR.LAST_NAME)
-        .from(BOOK)
-        .join(AUTHOR)
-        .on(BOOK.AUTHOR_ID.equal(AUTHOR.ID))
-        .where(BOOK.PUBLISHED_IN.equal(1948))
-        .fetch();
-    ```
+```java
+// Typesafely execute the SQL statement directly with jOOQ
+Result<Record3<String, String, String>> result = 
+create.select(BOOK.TITLE, AUTHOR.FIRST_NAME, AUTHOR.LAST_NAME)
+    .from(BOOK)
+    .join(AUTHOR)
+    .on(BOOK.AUTHOR_ID.equal(AUTHOR.ID))
+    .where(BOOK.PUBLISHED_IN.equal(1948))
+    .fetch();
+```
 
 Using this and the [DAO][dao] pattern, you can make database access a breeze.
 
@@ -616,26 +616,26 @@ asserting behavior of code that calls it.
 
 [jMock][jmock] is the standard mocking tool for Java. It looks like this:
 
-    ```java
-    public class FooWidgetTest {
-        private Mockery context = new Mockery();
+```java
+public class FooWidgetTest {
+    private Mockery context = new Mockery();
 
-        @Test
-        public void basicTest() {
-            final FooWidgetDependency dep = context.mock(FooWidgetDependency.class);
-            
-            context.checking(new Expectations() {{
-                oneOf(dep).call(with(any(String.class)));
-                atLeast(0).of(dep).optionalCall();
-            }});
+    @Test
+    public void basicTest() {
+        final FooWidgetDependency dep = context.mock(FooWidgetDependency.class);
+        
+        context.checking(new Expectations() {{
+            oneOf(dep).call(with(any(String.class)));
+            atLeast(0).of(dep).optionalCall();
+        }});
 
-            final FooWidget foo = new FooWidget(dep);
+        final FooWidget foo = new FooWidget(dep);
 
-            Assert.assertTrue(foo.doThing());
-            context.assertIsSatisfied();
-        }
+        Assert.assertTrue(foo.doThing());
+        context.assertIsSatisfied();
     }
-    ```
+}
+```
 
 This sets up a *FooWidgetDependency* via jMock and then adds expectations. We
 expect that *dep*'s *call* method will be called once with some String and that
@@ -649,22 +649,22 @@ put that in a [test fixture][junitfixture] and put *assertIsSatisfied* in an
 
 Do you ever do this with jUnit?
 
-    ```java
-    final List<String> result = some.testMethod();
-    assertEquals(4, result.size());
-    assertTrue(result.contains("some result"));
-    assertTrue(result.contains("some other result"));
-    assertFalse(result.contains("shouldn't be here"));
-    ```
+```java
+final List<String> result = some.testMethod();
+assertEquals(4, result.size());
+assertTrue(result.contains("some result"));
+assertTrue(result.contains("some other result"));
+assertFalse(result.contains("shouldn't be here"));
+```
 
 This is just annoying boilerplate. [AssertJ][assertj] solves this. You can
 transform the same code into this:
 
-    ```java
-    assertThat(some.testMethod()).hasSize(4)
-                                 .contains("some result", "some other result")
-                                 .doesNotContain("shouldn't be here");
-    ```
+```java
+assertThat(some.testMethod()).hasSize(4)
+                             .contains("some result", "some other result")
+                             .doesNotContain("shouldn't be here");
+```
 
 This fluent interface makes your tests more readable. What more could you want?
 
@@ -724,16 +724,16 @@ heap dump and lets you find the problem.
 There's a few ways to get a heap dump for a JVM process, but I use
 [jmap][jmap]:
 
-    ```bash
-    $ jmap -dump:live,format=b,file=heapdump.hprof -F 8152
-    Attaching to process ID 8152, please wait...
-    Debugger attached successfully.
-    Server compiler detected.
-    JVM version is 23.25-b01
-    Dumping heap to heapdump.hprof ...
-    ... snip ...
-    Heap dump file created
-    ```
+```bash
+$ jmap -dump:live,format=b,file=heapdump.hprof -F 8152
+Attaching to process ID 8152, please wait...
+Debugger attached successfully.
+Server compiler detected.
+JVM version is 23.25-b01
+Dumping heap to heapdump.hprof ...
+... snip ...
+Heap dump file created
+```
 
 Then you can open the *heapdump.hprof* file with the Memory Analyzer and see
 what's going on fast.


### PR DESCRIPTION
Since this is a github document, it might make sense to take advantage of github's syntax highlighting feature. 

A notable disadvantage of this is that code blocks cannot also be indented four spaces like normal markdown, so the plaintext version of the document is slightly less readable. Feel free to not merge on the basis of this or other reasons. 
