### PR TITLE
Fix link for Java Concurrency in Practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ Resources to help you become a Java master.
 ### Books
 
 * [Effective Java](http://www.amazon.com/Effective-Java-Edition-Joshua-Bloch/dp/0321356683)
-* [Java Concurrency in Practice](http://www.amazon.com/Java-Concurrency-Practice-Brian-Goetz/dp/032134960)
+* [Java Concurrency in Practice](http://www.amazon.com/Java-Concurrency-Practice-Brian-Goetz/dp/0321349601)
 * [Clean Code](http://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882/)
 
 ### Podcasts


### PR DESCRIPTION
The amazon link for "Java Concurrency in Practice" book seems navigating to error page (missing last digit of ISBN).